### PR TITLE
fix: add Suspense boundaries for useSearchParams pages

### DIFF
--- a/src/app/payment-attempt/page.tsx
+++ b/src/app/payment-attempt/page.tsx
@@ -1,5 +1,17 @@
+import { Suspense } from "react";
 import PaymentAttemptClient from "@/components/PaymentAttemptClient";
+import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 
 export default function PaymentAttempt() {
-  return <PaymentAttemptClient />;
+  return (
+    <Suspense
+      fallback={
+        <div className="flex items-center justify-center min-h-screen w-full bg-muted/30">
+          <LoadingSpinner size="lg" text="Loading checkout..." />
+        </div>
+      }
+    >
+      <PaymentAttemptClient />
+    </Suspense>
+  );
 }

--- a/src/app/payment-success/page.tsx
+++ b/src/app/payment-success/page.tsx
@@ -1,5 +1,16 @@
+import { Suspense } from "react";
 import PaymentSuccessPage from "@/components/PaymentSuccessPage";
 
 export default function PaymentSuccess() {
-  return <PaymentSuccessPage />;
+  return (
+    <Suspense
+      fallback={
+        <div className="flex items-center justify-center min-h-screen w-full bg-muted/30">
+          <p className="text-muted-foreground">Loading...</p>
+        </div>
+      }
+    >
+      <PaymentSuccessPage />
+    </Suspense>
+  );
 }


### PR DESCRIPTION
Next.js 16 requires useSearchParams() inside a Suspense boundary for static generation.

Pages fixed:
- /payment-attempt (uses useSearchParams via PaymentAttemptClient)
- /payment-success (uses useSearchParams via PaymentSuccessPage)

Without this, Vercel build fails with: useSearchParams() should be wrapped in a suspense boundary